### PR TITLE
Harden zip extraction against path traversal/symlinks and fix temp dir leak

### DIFF
--- a/gtweak/tweaks/tweak_group_appearance.py
+++ b/gtweak/tweaks/tweak_group_appearance.py
@@ -13,7 +13,7 @@ from gi.repository import Gtk
 from gi.repository import GLib
 from gtweak.tweakmodel import Tweak
 
-from gtweak.utils import walk_directories, make_combo_list_with_default, extract_zip_file, get_resource_dirs
+from gtweak.utils import walk_directories, make_combo_list_with_default, extract_zip_file, get_resource_dirs, assert_zip_member_safe
 from gtweak.gshellwrapper import GnomeShellFactory
 from gtweak.gtksettings import GtkSettingsManager
 from gtweak.widgets import (TweakPreferencesPage, GSettingsTweakComboRow,TweakPreferencesGroup, GSettingsFileChooserButtonTweak, FileChooserButton, build_label_beside_widget)
@@ -188,13 +188,14 @@ class ShellThemeInstallerTweak(Gtk.Box, Tweak):
                     if n.endswith("gnome-shell/theme.json"):
                         logging.info("New style theme detected (theme.json)")
                         #new style theme - extract the name from the json file
-                        tmp = tempfile.mkdtemp()
-                        z.extract(n, tmp)
-                        with open(os.path.join(tmp,n)) as f:
-                            try:
-                                theme_name = json.load(f)["shell-theme"]["name"]
-                            except:
-                                logging.warning("Invalid theme format", exc_info=True)
+                        with tempfile.TemporaryDirectory() as tmp:
+                            assert_zip_member_safe(z.getinfo(n), tmp)
+                            z.extract(n, tmp)
+                            with open(os.path.join(tmp, n)) as f:
+                                try:
+                                    theme_name = json.load(f)["shell-theme"]["name"]
+                                except (ValueError, KeyError, TypeError):
+                                    logging.warning("Invalid theme format", exc_info=True)
 
                 if not fragment:
                     raise Exception("Could not find gnome-shell.css")

--- a/gtweak/utils.py
+++ b/gtweak/utils.py
@@ -4,6 +4,7 @@
 
 import os.path
 import logging
+import stat
 import tempfile
 import shutil
 import subprocess
@@ -79,6 +80,30 @@ def walk_directories(dirs, filter_func):
     return valid
 
 
+def is_zip_symlink(member):
+    # Unix mode bits only live in external_attr when the entry was produced on
+    # a Unix-like system (create_system == 3). Windows-produced zips have no
+    # mode bits, so treat them as non-symlinks.
+    if member.create_system != 3:
+        return False
+    mode = (member.external_attr >> 16) & 0xFFFF
+    return stat.S_ISLNK(mode)
+
+
+def assert_zip_member_safe(member, dest_root):
+    if is_zip_symlink(member):
+        raise ValueError("Refusing symlink entry in zip: %r" % member.filename)
+    target = os.path.realpath(os.path.join(dest_root, member.filename))
+    root = os.path.realpath(dest_root)
+    try:
+        common = os.path.commonpath([target, root])
+    except ValueError as e:
+        # commonpath raises for mixed absolute/relative or different drives
+        raise ValueError("Zip entry escapes destination: %r" % member.filename) from e
+    if common != root:
+        raise ValueError("Zip entry escapes destination: %r" % member.filename)
+
+
 def extract_zip_file(z, members_path, dest):
     """ returns (true_if_extracted_ok, true_if_updated) """
     tmp = tempfile.mkdtemp()
@@ -87,14 +112,19 @@ def extract_zip_file(z, members_path, dest):
     ok = True
     updated = False
     try:
+        members = z.infolist()
+        for m in members:
+            assert_zip_member_safe(m, tmp)
         if os.path.exists(dest):
             shutil.rmtree(dest)
             updated = True
-        z.extractall(tmp)
-        shutil.copytree(tmpdest, dest)
-    except OSError:
+        z.extractall(tmp, members=members)
+        shutil.copytree(tmpdest, dest, symlinks=False)
+    except (OSError, ValueError):
         ok = False
         logging.warning("Error extracting zip", exc_info=True)
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
 
     if ok:
         logging.info("Extracted zip to %s, copied to %s" % (tmpdest, dest))


### PR DESCRIPTION
## What                                                                                                                                                                                                                                                                                                                                       
                                         
  Theme installer pulls user-supplied zips straight into `~/.themes` without checking the member paths. A crafted archive can use `../` entries or symlinks to drop files outside the theme dir.                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                
  ## Fix                                                                                                                                                                                                                                                                                                                                        
                                                            
  - Every member's resolved path has to stay under the destination                                                                                                                                                                                                                                                                              
  - Symlink entries are rejected up front
                                                                                                                                                                                                                                                                                                                                                
  ## Drive-by cleanup                                       

  - `extract_zip_file` was leaking its tmp dir on success, now cleaned up in a `finally`                                                                                                                                                                                                                                                        
  - Swapped the `theme.json` parse over to `TemporaryDirectory`
  - Passed `symlinks=False` to `copytree`                                                                                                                                                                                                                                                                                                       
  - Replaced the bare `except` around `json.load`       